### PR TITLE
修正卡片收藏無法套用.active問題

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,6 +14,11 @@ if (url.includes("index.html")) {
   initializeCheckoutPage();
 }
 
+// 收藏按鈕 .iconFav 的 .active ( 商品詳情頁 )
+  document.querySelectorAll(".btn-ghost").forEach((icon) => {
+    icon.addEventListener("click", () => icon.classList.toggle("active"));
+  });
+
 // 購物流程區塊判斷在哪頁該如何顯示(數字+文字+虛線)
 function setActiveStep(stepNumber) {
   const steps = document.querySelectorAll(".process-number");
@@ -97,12 +102,6 @@ if (url.includes("cart.html")) {
     resizeTimeout = setTimeout(() => {
       setupScrollTrigger();
     }, 200);
-  });
-
-
-// 收藏按鈕 .iconFav 的 .active ( 商品詳情頁 )
-  document.querySelectorAll(".btn-ghost").forEach((icon) => {
-    icon.addEventListener("click", () => icon.classList.toggle("active"));
   });
 
 //首頁


### PR DESCRIPTION
先前將 .card 的愛心收藏按鈕
放在 all.js 的第103~106行
卻發現這段程式碼無法套用
所以把這段程式碼改為放到第17~20行
讓程式碼片段能夠正確執行

若覺得放在這個位置不好看
可以自行調整位置 or 修改程式碼片段
只要讓 .iconFav 的程式碼可以正確執行就好！